### PR TITLE
fix for query::matches: remove unneeded debugprint and prevent panic!

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -400,8 +400,10 @@ pub fn matches(subject: &str, pattern: &str, position: usize) -> bool {
     match pattern.len() {
         0 => true,
         _ => {
-            println!("{} {} {}", subject, pattern, position);
-            let re: Regex = Regex::new(pattern).unwrap();
+            let re: Regex = match Regex::new(pattern) {
+                Ok(re) => re,
+                Err(_) => return false
+            };
             re.is_match_at(&subject, position)
         }
     }


### PR DESCRIPTION
query::matches: 
  * remove an unneeded debugprint 
  * return false instead of panic! when an invalid Regex is passed