### PR TITLE
Return empty string when chop::before is called with the subject's prefix

### DIFF
--- a/src/chop.rs
+++ b/src/chop.rs
@@ -558,52 +558,23 @@ pub fn removesuffix(subject: &str, prefix: &str) -> String {
 /// // => "iami"
 /// ```
 pub fn slice(subject: &str, start: isize, end: isize) -> String {
-    let end_opt = if end == 0 { None } else { Some(end) };
-    slice_fixed(subject, start, end_opt)
-}
-
-/// Extracts from `subject` a string from `start` position up to `end` position. The character at `end` position is not included.
-///
-/// # Arguments
-///
-/// * `subject` - The string to extract from.
-/// * `start` - The position to start extraction. 0 means extract from the beginning of the `subject`. If negative use `subject.len() - start`.
-/// * `end` - The position to end extraction. `None` means extract to the end of the `subject`. If negative use `subject.len() - end`.
-///
-/// # Example
-/// ```
-/// use voca_rs::*;
-/// chop::slice("miami", 1, 0);
-/// // => "iami"
-/// chop::slice("błąd", -2, 0);
-/// // => "ąd"
-/// chop::slice("florida", 1, 4);
-/// // => "lor"
-/// chop::slice("e\u{0301}", 1, 0); // or 'é'
-/// // => "\u{0301}"
-/// chop::slice("Die Schildkröte fliegt.", 4, -8);
-/// // => "Schildkröte"
-/// use voca_rs::Voca;
-/// "miami"._slice(1, 0);
-/// // => "iami"
-/// ```
-pub fn slice_fixed(subject: &str, start: isize, end: Option<isize>) -> String {
-    //TODO choose a better name for this function
     let subject_length = crate::split::chars(subject).len();
-    let position_start = calculate_position(subject_length, start);
-    let position_end = if let Some(end) = end {
-        calculate_position(subject_length, end)
-    } else {
-        subject_length
-    };
+    let position_start = calculate_position(subject_length, start, true);
+    let position_end = calculate_position(subject_length, end, false);
 
-    fn calculate_position(length: usize, x: isize) -> usize {
+    fn calculate_position(length: usize, x: isize, start: bool) -> usize {
         if x < 0 {
             let pos = length as isize - x.abs();
             if pos < 0 {
                 0
             } else {
                 pos as usize
+            }
+        } else if x == 0 {
+            if start {
+                0
+            } else {
+                length
             }
         } else if x > length as isize {
             length

--- a/src/chop.rs
+++ b/src/chop.rs
@@ -148,6 +148,8 @@ pub fn after_last(subject: &str, search: &str) -> String {
 /// * `subject` - The string to extract from.
 /// * `search` - The substring to look for.
 ///
+/// If `search` is found at the start of `subject`, an empty string is returned.
+///
 /// # Example
 /// ```
 /// use voca_rs::*;

--- a/src/chop.rs
+++ b/src/chop.rs
@@ -67,16 +67,23 @@ fn return_after_or_before_and_after_last_or_before_last(
     if start_position == -1 {
         return "".to_owned();
     }
+    if start_position == 0 {
+        if let ReturnType::BeforeNormal | ReturnType::BeforeLast = return_type {
+            // A special check is needed for this case because `chop::slice` interprets an end position of 0 as "end at the last index"
+            // which means it would incorrectly return the entire `subject`, but if we want everything before the first index, that's just nothing.
+            return "".to_owned();
+        }
+    }
     let the_length = crate::count::count(search) as isize;
     let chop_start_position = match return_type {
         ReturnType::AfterNormal | ReturnType::AfterLast => start_position + the_length,
         ReturnType::BeforeNormal | ReturnType::BeforeLast => 0,
     };
     let chop_end_position = match return_type {
-        ReturnType::AfterNormal | ReturnType::AfterLast => None,
-        ReturnType::BeforeNormal | ReturnType::BeforeLast => Some(start_position),
+        ReturnType::AfterNormal | ReturnType::AfterLast => 0,
+        ReturnType::BeforeNormal | ReturnType::BeforeLast => start_position,
     };
-    crate::chop::slice_fixed(subject, chop_start_position, chop_end_position)
+    crate::chop::slice(subject, chop_start_position, chop_end_position)
 }
 /// Returns everything after the given `search`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,6 @@
 #![crate_name = "voca_rs"]
-#![deny(
-    warnings,
-    unused_variables,
-    missing_docs,
-    unused_extern_crates
-)]
+#![deny(warnings, unused_variables, missing_docs, unused_extern_crates)]
+#![allow(unexpected_cfgs)]
 #![forbid(unsafe_code)]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 

--- a/src/manipulate.rs
+++ b/src/manipulate.rs
@@ -503,7 +503,7 @@ pub fn splice(subject: &str, start: isize, delete_count: usize, to_add: &str) ->
                 "{}{}{}",
                 crate::chop::first(subject, start_position),
                 to_add,
-                crate::chop::slice_fixed(subject, end_position as isize, None)
+                crate::chop::slice(subject, end_position as isize, 0)
             )
         }
     }
@@ -709,10 +709,7 @@ pub fn word_wrap(subject: &str, width: usize, newline: &str, indent: &str) -> St
         let mut subj_part = crate::chop::prune(&string, length, "+");
         subj_part = trim(&crate::chop::slice(&subj_part, 0, -1), "");
         let length_to_cut = crate::count::count_graphemes(&subj_part);
-        string = trim(
-            &crate::chop::slice_fixed(&string, length_to_cut as isize, None),
-            "",
-        );
+        string = trim(&crate::chop::slice(&string, length_to_cut as isize, 0), "");
         subject_len = crate::count::count_graphemes(&string);
 
         if subj_part == string || subj_part.is_empty() {

--- a/src/manipulate.rs
+++ b/src/manipulate.rs
@@ -503,7 +503,7 @@ pub fn splice(subject: &str, start: isize, delete_count: usize, to_add: &str) ->
                 "{}{}{}",
                 crate::chop::first(subject, start_position),
                 to_add,
-                crate::chop::slice(subject, end_position as isize, 0)
+                crate::chop::slice_fixed(subject, end_position as isize, None)
             )
         }
     }
@@ -709,7 +709,10 @@ pub fn word_wrap(subject: &str, width: usize, newline: &str, indent: &str) -> St
         let mut subj_part = crate::chop::prune(&string, length, "+");
         subj_part = trim(&crate::chop::slice(&subj_part, 0, -1), "");
         let length_to_cut = crate::count::count_graphemes(&subj_part);
-        string = trim(&crate::chop::slice(&string, length_to_cut as isize, 0), "");
+        string = trim(
+            &crate::chop::slice_fixed(&string, length_to_cut as isize, None),
+            "",
+        );
         subject_len = crate::count::count_graphemes(&string);
 
         if subj_part == string || subj_part.is_empty() {

--- a/tests/unit/chop.rs
+++ b/tests/unit/chop.rs
@@ -8,17 +8,11 @@ fn after() {
         voca_rs::chop::after("This is my name", "This is"),
         " my name"
     );
-    assert_eq!(
-        voca_rs::chop::after("This is my name", "tHiS IS"),
-        ""
-    );
-    assert_eq!(
-        voca_rs::chop::after("This is my name", "my name"),
-        ""
-    );
+    assert_eq!(voca_rs::chop::after("This is my name", "tHiS IS"), "");
+    assert_eq!(voca_rs::chop::after("This is my name", "my name"), "");
     assert_eq!(
         voca_rs::chop::after("This is my name", ""),
-        ""
+        "This is my name"
     );
     assert_eq!(
         voca_rs::chop::after("S̃o̊m̋ȩ̈ gḷ̉y̌p̆ẖs a̋řẹ̆̇ hër̵ē̱", "gḷ̉y̌p̆ẖs"),
@@ -63,18 +57,9 @@ fn before() {
         voca_rs::chop::before("This is my name", "my name"),
         "This is "
     );
-    assert_eq!(
-        voca_rs::chop::before("This is my name", "My NAME"),
-        ""
-    );
-    assert_eq!(
-        voca_rs::chop::before("This is my name", "This is"),
-        ""
-    );
-    assert_eq!(
-        voca_rs::chop::before("This is my name", ""),
-        ""
-    );
+    assert_eq!(voca_rs::chop::before("This is my name", "My NAME"), "");
+    assert_eq!(voca_rs::chop::before("This is my name", "This is"), "");
+    assert_eq!(voca_rs::chop::before("This is my name", ""), "");
     assert_eq!(
         voca_rs::chop::before("S̃o̊m̋ȩ̈ gḷ̉y̌p̆ẖs a̋řẹ̆̇ hër̵ē̱", "gḷ̉y̌p̆ẖs"),
         "S̃o̊m̋ȩ̈ "

--- a/tests/unit/chop.rs
+++ b/tests/unit/chop.rs
@@ -9,6 +9,18 @@ fn after() {
         " my name"
     );
     assert_eq!(
+        voca_rs::chop::after("This is my name", "tHiS IS"),
+        ""
+    );
+    assert_eq!(
+        voca_rs::chop::after("This is my name", "my name"),
+        ""
+    );
+    assert_eq!(
+        voca_rs::chop::after("This is my name", ""),
+        ""
+    );
+    assert_eq!(
         voca_rs::chop::after("S̃o̊m̋ȩ̈ gḷ̉y̌p̆ẖs a̋řẹ̆̇ hër̵ē̱", "gḷ̉y̌p̆ẖs"),
         " a̋řẹ̆̇ hër̵ē̱"
     );
@@ -50,6 +62,18 @@ fn before() {
     assert_eq!(
         voca_rs::chop::before("This is my name", "my name"),
         "This is "
+    );
+    assert_eq!(
+        voca_rs::chop::before("This is my name", "My NAME"),
+        ""
+    );
+    assert_eq!(
+        voca_rs::chop::before("This is my name", "This is"),
+        ""
+    );
+    assert_eq!(
+        voca_rs::chop::before("This is my name", ""),
+        ""
     );
     assert_eq!(
         voca_rs::chop::before("S̃o̊m̋ȩ̈ gḷ̉y̌p̆ẖs a̋řẹ̆̇ hër̵ē̱", "gḷ̉y̌p̆ẖs"),


### PR DESCRIPTION
## Why?
I noticed that if the argument passed to `before` appears at the beginning of the subject string, the entire subject string is returned instead of an empty string as I expected.

I discovered that this was happening because in that situation, `before` calls `slice` with a `start` of 0 and `end` of 0, and `slice` treats an `end` of 0 to mean that the end should be the end of the whole string. Ideally `slice` would be able to differentiate between "the end index should be 0" and "the end index should be the final index", but that would require a change to the function's signature, and since it's part of the crate's public API I didn't think it would be feasible. So instead I added a check to `return_after_or_before_and_after_last_or_before_last` to skip calling `slice` entirely and just return an empty string if it's asked to find characters before something and that something is at the beginning of the subject string.

I also added `#![allow(unexpected_cfgs)]` in `lib.rs`. A warning was added for unknown feature names in Rust 1.80.0, so `deny(warnings)` was turning the warning on `#![cfg_attr(all(test, feature = "nightly"), feature(test))]` into a compile error.

## Without this change
`"this is something"._before("this")` returns `"this is something"`

## With this change
`"this is something"._before("this")` returns `""`